### PR TITLE
ADD possibility to serialize NSNull values (opt-in) eventhough conver…

### DIFF
--- a/JAGPropertyConverter.xcodeproj/project.pbxproj
+++ b/JAGPropertyConverter.xcodeproj/project.pbxproj
@@ -30,12 +30,13 @@
 		890F5D451B5948A400246901 /* NSDictionary+JAGKeyValueSwapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 890F5D421B5948A400246901 /* NSDictionary+JAGKeyValueSwapping.m */; };
 		890F5D471B594A4F00246901 /* DictionarySwappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 890F5D461B594A4F00246901 /* DictionarySwappingTest.m */; };
 		891B9BCD1B554CE000DF255E /* JAGPropertyConverter+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */; };
+		898EB2661CD11BCB00F2A9BA /* OptInNullValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 898EB2651CD11BCB00F2A9BA /* OptInNullValues.swift */; };
 		89C0B7971A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C0B7951A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h */; };
 		89C0B7981A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */; };
 		89C0B7991A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */; };
 		89C0B7A11A278D3D007AA954 /* SnakeCaseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */; };
 		89C0B7B21A28AF2B007AA954 /* JAGPropertyMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C0B7B11A28AF2B007AA954 /* JAGPropertyMapping.h */; };
-		89C7085C1BDAF3FB00749C93 /* JAGPropertyConverterSubclassTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C7085B1BDAF3FB00749C93 /* JAGPropertyConverterSubclassTest.m */; settings = {ASSET_TAGS = (); }; };
+		89C7085C1BDAF3FB00749C93 /* JAGPropertyConverterSubclassTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C7085B1BDAF3FB00749C93 /* JAGPropertyConverterSubclassTest.m */; };
 		89DED0591A7AAEDD009BF46F /* NullValuesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0581A7AAEDD009BF46F /* NullValuesTest.m */; };
 		89DED0631A7AB2C5009BF46F /* NumberTestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0601A7AB2C5009BF46F /* NumberTestModel.m */; };
 		89DED0641A7AB2C5009BF46F /* TestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0621A7AB2C5009BF46F /* TestModel.m */; };
@@ -85,6 +86,8 @@
 		890F5D421B5948A400246901 /* NSDictionary+JAGKeyValueSwapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+JAGKeyValueSwapping.m"; sourceTree = "<group>"; };
 		890F5D461B594A4F00246901 /* DictionarySwappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DictionarySwappingTest.m; sourceTree = "<group>"; };
 		891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverter+Subclass.h"; sourceTree = "<group>"; };
+		898EB2641CD11BCA00F2A9BA /* JAGPropertyConverterTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverterTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		898EB2651CD11BCB00F2A9BA /* OptInNullValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptInNullValues.swift; sourceTree = "<group>"; };
 		89C0B7951A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+JAGSnakeCaseSupport.h"; sourceTree = "<group>"; };
 		89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+JAGSnakeCaseSupport.m"; sourceTree = "<group>"; };
 		89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnakeCaseTest.m; sourceTree = "<group>"; };
@@ -193,6 +196,7 @@
 				89DED0581A7AAEDD009BF46F /* NullValuesTest.m */,
 				11E60F53160A7436000BD25F /* NumberFormatterTest.h */,
 				11E60F54160A7436000BD25F /* NumberFormatterTest.m */,
+				898EB2651CD11BCB00F2A9BA /* OptInNullValues.swift */,
 				11275B8714E9D8BD00C4707C /* PropertyModelTests.h */,
 				11275B8814E9D8BD00C4707C /* PropertyModelTests.m */,
 				89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */,
@@ -206,6 +210,7 @@
 		11275B6514E9D56200C4707C /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				898EB2641CD11BCA00F2A9BA /* JAGPropertyConverterTests-Bridging-Header.h */,
 				11275B6614E9D56200C4707C /* JAGPropertyConverterTests-Info.plist */,
 				11275B6714E9D56200C4707C /* InfoPlist.strings */,
 			);
@@ -285,6 +290,7 @@
 		11275B4214E9D56200C4707C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0730;
 				LastTestingUpgradeCheck = 0640;
 				LastUpgradeCheck = 0700;
 			};
@@ -341,6 +347,7 @@
 				89DED0641A7AB2C5009BF46F /* TestModel.m in Sources */,
 				11275B8B14E9D8BD00C4707C /* JAGPropertyConverterTest.m in Sources */,
 				89C7085C1BDAF3FB00749C93 /* JAGPropertyConverterSubclassTest.m in Sources */,
+				898EB2661CD11BCB00F2A9BA /* OptInNullValues.swift in Sources */,
 				8C2232ED1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m in Sources */,
 				89C0B7991A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */,
 				11275B8C14E9D8BD00C4707C /* JAGPropertyFinderTest.m in Sources */,
@@ -408,7 +415,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -438,7 +445,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -471,22 +478,29 @@
 		11275B7314E9D56200C4707C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JAGPropertyConverter/JAGPropertyConverter-Prefix.pch";
 				INFOPLIST_FILE = "JAGPropertyConverterTests/JAGPropertyConverterTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.threedeadmonks.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "JAGPropertyConverterTests/JAGPropertyConverterTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		11275B7414E9D56200C4707C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JAGPropertyConverter/JAGPropertyConverter-Prefix.pch";
 				INFOPLIST_FILE = "JAGPropertyConverterTests/JAGPropertyConverterTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.threedeadmonks.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "JAGPropertyConverterTests/JAGPropertyConverterTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/JAGPropertyConverter.xcodeproj/project.pbxproj
+++ b/JAGPropertyConverter.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		890F5D411B5948A400246901 /* NSDictionary+JAGKeyValueSwapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+JAGKeyValueSwapping.h"; sourceTree = "<group>"; };
 		890F5D421B5948A400246901 /* NSDictionary+JAGKeyValueSwapping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+JAGKeyValueSwapping.m"; sourceTree = "<group>"; };
 		890F5D461B594A4F00246901 /* DictionarySwappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DictionarySwappingTest.m; sourceTree = "<group>"; };
+		891AE7461CD8C55800206542 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverter+Subclass.h"; sourceTree = "<group>"; };
 		898EB2641CD11BCA00F2A9BA /* JAGPropertyConverterTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverterTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		898EB2651CD11BCB00F2A9BA /* OptInNullValues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptInNullValues.swift; sourceTree = "<group>"; };
@@ -126,6 +127,7 @@
 		11275B4014E9D56200C4707C = {
 			isa = PBXGroup;
 			children = (
+				891AE7461CD8C55800206542 /* README.md */,
 				11275B5014E9D56200C4707C /* JAGPropertyConverter */,
 				11275B6414E9D56200C4707C /* JAGPropertyConverterTests */,
 				11275B4D14E9D56200C4707C /* Frameworks */,

--- a/JAGPropertyConverter.xcodeproj/xcshareddata/xcbaselines/11275B5A14E9D56200C4707C.xcbaseline/814F8B37-F661-4313-8FC6-7E4BC6B6E64D.plist
+++ b/JAGPropertyConverter.xcodeproj/xcshareddata/xcbaselines/11275B5A14E9D56200C4707C.xcbaseline/814F8B37-F661-4313-8FC6-7E4BC6B6E64D.plist
@@ -39,6 +39,16 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testBenchmarkModelToJson</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0050976</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 		</dict>
 	</dict>
 </dict>

--- a/JAGPropertyConverter/JAGPropertyConverter.h
+++ b/JAGPropertyConverter/JAGPropertyConverter.h
@@ -32,11 +32,11 @@
  * The type of output the objects will be converted to.
  * @see outputType for more detailed description.
  */
-typedef enum {
+typedef NS_ENUM(NSInteger, JAGOutputType) {
     kJAGFullOutput,
     kJAGPropertyListOutput,
     kJAGJSONOutput
-} JAGOutputType;
+};
 
 ///A Block to identify what class a dictionary represents.
 typedef Class (^IdentifyBlock)(NSString *dictName, NSDictionary *dictionary);
@@ -143,7 +143,7 @@ typedef id (^ConvertBlock)(id obj);
  * of these classes, the converter will coerce an unidentified NSDictionary
  * into the property.
  */
-@property (nonatomic, strong) NSSet *classesToConvert;
+@property (nonatomic, strong) NSSet<Class> *classesToConvert;
 
 /**
  * A Block to convert a (JSON) property to an NSDate.

--- a/JAGPropertyConverter/JAGPropertyConverter.m
+++ b/JAGPropertyConverter/JAGPropertyConverter.m
@@ -285,7 +285,7 @@
         
         // check if we need to convert nil values into NSNull
         BOOL shouldIgnoreNilValue = self.shouldIgnoreNullValues;
-        if (self.shouldIgnoreNullValues && [nilPropertiesNotToIgnore containsObject:propertyName]) {
+        if (shouldIgnoreNilValue && [nilPropertiesNotToIgnore containsObject:[property name]]) { // using original model property name and not custom or snake_case version
             shouldIgnoreNilValue = NO;
         }
         
@@ -299,7 +299,7 @@
             BOOL isKeyPath = [self _isKeyPathKey:customKey];
             if (isKeyPath) {
                 BOOL shouldIgnoreNilValue = self.shouldIgnoreNullValues;
-                if (self.shouldIgnoreNullValues && [nilPropertiesNotToIgnore containsObject:customKey]) {
+                if (shouldIgnoreNilValue && [nilPropertiesNotToIgnore containsObject:customKey]) {
                     shouldIgnoreNilValue = NO;
                 }
                 [values setValue:[self recursiveDecomposeObject:[model valueForKeyPath:customKey] shouldIgnoreNilValue:shouldIgnoreNilValue] forKey:customMapping[customKey]];

--- a/JAGPropertyConverter/JAGPropertyMapping.h
+++ b/JAGPropertyConverter/JAGPropertyMapping.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @note This method is only used if `converter.shouldIgnoreNullValues == YES`
  
- @return Array of property names to not be ignored when serializing nil values.
+ @return Array of original model property names to not be ignored when serializing nil values.
  */
 + (NSArray<NSString *> *)nilPropertiesNotToIgnore;
 

--- a/JAGPropertyConverter/JAGPropertyMapping.h
+++ b/JAGPropertyConverter/JAGPropertyMapping.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol JAGPropertyMapping <NSObject>
 
 @optional
@@ -18,7 +20,7 @@
  *
  * @return A dictionary with property name as key and JSON name as value: Dict <property name, JSON name>
  */
-+ (NSDictionary *)customPropertyNamesMapping;
++ (NSDictionary<NSString *, NSString *> *)customPropertyNamesMapping;
 
 /** Asks the receiver if there are any enum values which should be converted (Model <> JSON). Implement convertToEnum and convertFromEnum to handle this.
  *
@@ -28,12 +30,24 @@
  *
  * @return A dictionary with property name as key and JSON name as value: Dict <property name, JSON name>
  */
-+ (NSDictionary *)enumPropertiesToConvert;
++ (NSDictionary<NSString *, NSString *> *)enumPropertiesToConvert;
 
 /** Asks the receiver if there are properties to ignore when converting from JSON. */
-+ (NSArray *)ignorePropertiesFromJSON;
++ (NSArray<NSString *> *)ignorePropertiesFromJSON;
 
 /** Asks the receiver if there are properties to ignore when converting to JSON. */
-+ (NSArray *)ignorePropertiesToJSON;
++ (NSArray<NSString *> *)ignorePropertiesToJSON;
+
+/** Tells the property converter to not ignore specified properties when property value is nil (= opt-In to not be ignored).
+ 
+ It will either convert the property to NSNull (model ➡️ json) or set property to nil (json ➡️ model).
+ 
+ @note This method is only used if `converter.shouldIgnoreNullValues == YES`
+ 
+ @return Array of property names to not be ignored when serializing nil values.
+ */
++ (NSArray<NSString *> *)nilPropertiesNotToIgnore;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JAGPropertyConverterTests/JAGPropertyConverterTests-Bridging-Header.h
+++ b/JAGPropertyConverterTests/JAGPropertyConverterTests-Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "JAGPropertyConverter.h"
+
+#import "NumberTestModel.h"
+#import "TestModel.h"
+#import "TestModelCustomSubclass.h"

--- a/JAGPropertyConverterTests/JAGPropertyTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyTest.m
@@ -235,4 +235,20 @@
     XCTAssertTrue([modelProp canAcceptValue:value], @"model properties should be able to accept TestModel-valued ids.");
 }
 
+#pragma mark - Tests for NSObject
+
+- (void)testIsEqual {
+    JAGProperty *anotherStringProp = [JAGPropertyFinder propertyForName:@"stringProperty" inClass:[TestModel class]];
+    
+    XCTAssertTrue(stringProp != anotherStringProp, @"should be different instances.");
+    XCTAssertTrue([stringProp isEqual:anotherStringProp], @"but `isEqual:` is overridden");
+}
+
+- (void)testHash {
+    JAGProperty *anotherStringProp = [JAGPropertyFinder propertyForName:@"stringProperty" inClass:[TestModel class]];
+    
+    XCTAssertTrue(stringProp != anotherStringProp, @"should be different instances.");
+    XCTAssertEqual(stringProp.hash, anotherStringProp.hash);
+}
+
 @end

--- a/JAGPropertyConverterTests/OptInNullValues.swift
+++ b/JAGPropertyConverterTests/OptInNullValues.swift
@@ -18,6 +18,10 @@ class OptInNullValueTestModel: NSObject, JAGPropertyMapping {
     static func nilPropertiesNotToIgnore() -> [String] {
         return ["stringProperty", "arrayProperty"]
     }
+    
+    static func customPropertyNamesMapping() -> [String : String] {
+        return ["stringProperty" : "strProperty"]
+    }
 }
 
 /// This tests the new feature to opt-in sending null values if a property is nil when `converter.shouldIgnoreNullValues == true`
@@ -34,6 +38,7 @@ class OptInNullValues: XCTestCase {
         converter.outputType = .JAGJSONOutput
         converter.classesToConvert = NSSet(array: [OptInNullValueTestModel.self]) as Set<NSObject>
         converter.shouldIgnoreNullValues = true
+        converter.enableSnakeCaseSupport = true
         
         let formatter = NSNumberFormatter()
         formatter.locale = NSLocale(localeIdentifier: "en")
@@ -45,14 +50,14 @@ class OptInNullValues: XCTestCase {
         model.intProperty = 1337
         model.stringProperty = "Unicorns! 🦄🦄🦄"
         model.numberProperty = 7777
-        model.arrayProperty = ["🌰🌰🌰"]
+        model.arrayProperty = ["🌰🌰🌰"] // nuts! ;)
         
         XCTAssertEqual(model.intProperty, 1337)
         XCTAssertEqual(model.stringProperty, "Unicorns! 🦄🦄🦄")
         XCTAssertEqual(model.numberProperty, 7777)
         XCTAssertEqual(model.arrayProperty!, ["🌰🌰🌰"])
         
-        let dict = [ "intProperty" : NSNull(), "stringProperty" : NSNull(), "arrayProperty" : NSNull() ]    // leave out numberProperty; we don't want to touch it
+        let dict = [ "intProperty" : NSNull(), "strProperty" : NSNull(), "arrayProperty" : NSNull() ]    // leave out numberProperty; we don't want to touch it
         
         converter.setPropertiesOf(model, fromDictionary: dict)
         
@@ -74,7 +79,7 @@ class OptInNullValues: XCTestCase {
         XCTAssertNil(model.arrayProperty)
         
         let dict = converter.decomposeObject(model) as! NSDictionary
-        let expectedDict = [ "intProperty" : 42, "stringProperty" : NSNull(), "arrayProperty" : NSNull() ] // only stringProperty is optIn; so numberProperty will be ignored (= not in dict)
+        let expectedDict = [ "int_property" : 42, "str_property" : NSNull(), "array_property" : NSNull() ] // only stringProperty is optIn; so numberProperty will be ignored (= not in dict)
         
         XCTAssertEqual(dict, expectedDict)
     }

--- a/JAGPropertyConverterTests/OptInNullValues.swift
+++ b/JAGPropertyConverterTests/OptInNullValues.swift
@@ -1,0 +1,81 @@
+//
+//  OptInNullValues.swift
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 27.04.16.
+//
+//
+
+import XCTest
+
+@objc(OptInNullValueTestModel)
+class OptInNullValueTestModel: NSObject, JAGPropertyMapping {
+    var intProperty: Int = 0
+    var stringProperty: String?
+    var numberProperty: NSNumber?
+    var arrayProperty: [String]?
+    
+    static func nilPropertiesNotToIgnore() -> [String] {
+        return ["stringProperty", "arrayProperty"]
+    }
+}
+
+/// This tests the new feature to opt-in sending null values if a property is nil when `converter.shouldIgnoreNullValues == true`
+class OptInNullValues: XCTestCase {
+    private var model: OptInNullValueTestModel!
+    private var converter: JAGPropertyConverter!
+    
+    override func setUp() {
+        super.setUp()
+        
+        model = OptInNullValueTestModel()
+        
+        converter = JAGPropertyConverter()
+        converter.outputType = .JAGJSONOutput
+        converter.classesToConvert = NSSet(array: [OptInNullValueTestModel.self]) as Set<NSObject>
+        converter.shouldIgnoreNullValues = true
+        
+        let formatter = NSNumberFormatter()
+        formatter.locale = NSLocale(localeIdentifier: "en")
+        converter.numberFormatter = formatter
+    }
+    
+    // json --> model
+    func testOptInJsonToModel() {
+        model.intProperty = 1337
+        model.stringProperty = "Unicorns! 🦄🦄🦄"
+        model.numberProperty = 7777
+        model.arrayProperty = ["🌰🌰🌰"]
+        
+        XCTAssertEqual(model.intProperty, 1337)
+        XCTAssertEqual(model.stringProperty, "Unicorns! 🦄🦄🦄")
+        XCTAssertEqual(model.numberProperty, 7777)
+        XCTAssertEqual(model.arrayProperty!, ["🌰🌰🌰"])
+        
+        let dict = [ "intProperty" : NSNull(), "stringProperty" : NSNull(), "arrayProperty" : NSNull() ]    // leave out numberProperty; we don't want to touch it
+        
+        converter.setPropertiesOf(model, fromDictionary: dict)
+        
+        XCTAssertEqual(model.intProperty, 1337, "NSNull values should be ignored")
+        XCTAssertNil(model.stringProperty, "stringProperty should be nil, because it was optIn for deletion")
+        XCTAssertEqual(model.numberProperty, 7777, "as this property was not in the dictionary, it should be untouched")
+        XCTAssertNil(model.arrayProperty)
+    }
+    
+    // model --> json
+    func testOptInModelToJson() {
+        model.intProperty = 42
+        model.stringProperty = nil
+        model.numberProperty = nil
+        model.arrayProperty = nil
+        
+        XCTAssertNil(model.stringProperty)
+        XCTAssertNil(model.numberProperty)
+        XCTAssertNil(model.arrayProperty)
+        
+        let dict = converter.decomposeObject(model) as! NSDictionary
+        let expectedDict = [ "intProperty" : 42, "stringProperty" : NSNull(), "arrayProperty" : NSNull() ] // only stringProperty is optIn; so numberProperty will be ignored (= not in dict)
+        
+        XCTAssertEqual(dict, expectedDict)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ JAGPropertyConverter also supports conversion of NS_ENUMs to strings and vice-ve
 * Support converting `NSData` (eg. into Base64 strings): `convertToData` and `convertFromData`
 * Support converting enums: `convertToEnum` and `convertFromEnum`
 * Support for auto converting to/from **snake_case**: `enableSnakeCaseSupport`
-* Support for ingoring `nil`/`null` vales: `shouldIngoreNullValues`
+* Support for ingoring `nil`/`null` values: `shouldIngoreNullValues` (exception list using `nilPropertiesNotToIgnore`)
 * Support to ignore `weak` properties for serialization: `shouldConvertWeakProperties`
 * Extracted and restructured some methods so JAGPropertyConverter can be subclassed: `JAGPropertyConverter+Subclass.h`
 * Enhanced `identifyDict`: it will now pass in the dictionary name (breaking change!)


### PR DESCRIPTION
- ADD possibility to serialize NSNull values (opt-in) eventhough `converter.shouldIgnoreNullValues` is set to `YES`. New `JAGPropertyMapping` method: `nilPropertiesNotToIgnore`
- ADD nullability and generics to `JAGPropertyMapping.h`
- MOD converted `JAGOutputType` to `NS_ENUM`
- MOD increased minimum deployment target to 7.0 (was 5.0) (otherwise we couldn't use Swift in unit tests)

Not sure about the naming of the new protocol method and variables yet. Maybe you have better ideas? :)
