### PR TITLE
MOD respect `shouldIgnoreNullValues` flag also when composing arrays …

### DIFF
--- a/JAGPropertyConverter/JAGPropertyConverter.m
+++ b/JAGPropertyConverter/JAGPropertyConverter.m
@@ -319,6 +319,10 @@
     for (id elt in collection) {
         id value = [self composeModelFromObject:elt propertyName:propertyName];
         if (value) {
+            // NSNull handling
+            if (self.shouldIgnoreNullValues && [value isKindOfClass:[NSNull class]]) {
+                continue;
+            }
             [mutableCollection addObject: value];
         } else {
             NSLog(@"Object %@ can't be converted to properties.", [elt class]);
@@ -359,7 +363,12 @@
         } else {
             NSMutableDictionary *dict = [NSMutableDictionary dictionary];
             for (id key in object) {
-                [dict setValue: [self composeModelFromObject: [object valueForKey: key] propertyName:key]
+                id value = [self composeModelFromObject: [object valueForKey: key] propertyName:key];
+                // NSNull handling
+                if (self.shouldIgnoreNullValues && [value isKindOfClass:[NSNull class]]) {
+                    continue;
+                }
+                [dict setValue: value
                         forKey: key];
             }
             return dict;

--- a/JAGPropertyConverterTests/JAGPropertyConverterTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyConverterTest.m
@@ -228,6 +228,29 @@
     XCTAssertNil(testModel.stringProperty, @"");
 }
 
+- (void) testIgnoringNSNullValuesInDictionaryFromJson {
+    converter.shouldIgnoreNullValues = YES;
+    
+    NSDictionary *dict = @{ @"dictionaryProperty" : @{ @"nullValue" : [NSNull null],
+                                                       @"nonNullValue" : @42 }};
+    
+    TestModel *testModel = [TestModel testModel];
+    [converter setPropertiesOf:testModel fromDictionary:dict];
+    
+    XCTAssertEqualObjects(testModel.dictionaryProperty, @{ @"nonNullValue" : @42 }, @"The converter ignores NSNull values in arrays when composing objects.");
+}
+
+- (void) testIgnoringNSNullValuesInArrayFromJson {
+    converter.shouldIgnoreNullValues = YES;
+    
+    NSDictionary *dict = @{ @"arrayProperty" : @[ [NSNull null], @42 ]};
+    
+    TestModel *testModel = [TestModel testModel];
+    [converter setPropertiesOf:testModel fromDictionary:dict];
+    
+    XCTAssertEqualObjects(testModel.arrayProperty, @[ @42 ], @"The converter ignores NSNull values in arrays when composing objects.");
+}
+
 #pragma mark - Snake Case
 
 - (void)testSnakeCaseSupport1 {


### PR DESCRIPTION
…and dictionaries from JSON

Here's something to think about...

shouldn't we also include the contents of arrays and dictionaries to respect the `shouldIgnoreNullValues` flag of the `JAGPropertyConverter`? At least for the parsing from JSON.

I currently have a use case where this is very likely to happen